### PR TITLE
Correct the principle stated in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Target: `net9.0`.
 
 ## Principle
 
-Every operation is an object. Objects are composed by decoration. A result is produced when it is asked for.
+Objects are results of behaviour. `Upper` is uppercase text, `Filtered` is a filtered sequence, `Maximum` is the greatest item of a sequence — each name says what the object is. Objects are composed by decoration, and the result is produced when it is asked for.
 
 ```csharp
 using Tonga.Enumerable;
@@ -105,8 +105,8 @@ LINQ has no counterpart here; the left column shows what is written otherwise.
 | Abstraction | Role |
 |---|---|
 | `IFact` | a statement that is true or false — composable through `And`, `Or`, `Not` |
-| `IPipe<In,Out>` | a transformation as an object, including `Conditional` and `Mux` |
-| `ITap` | a side effect as an object |
+| `IPipe<In,Out>` | a transformation, including `Conditional` and `Mux` |
+| `ITap` | a side effect |
 | `IConduit` | a stream source, decorable through `TeeOnRead`, `GZipCompressing`, `LoggingOnReadConduit` |
 | `IOptional` | a value that may be absent, without `null` |
 | `IMap` | an immutable mapping with `With` and `Lazy` |


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

README only, no code touched, so the build box holds trivially and no test applies. Branch is `main` (`4d94d72`) plus one commit.

### What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: documentation

### What is the current behavior? (You can also link to an open issue here)

The Principle section opened with:

> Every operation is an object.

That inverts what EO says. An operation is not an object; objects are results of behaviour, and an object's name states what it is. `Upper` is uppercase text, not the act of uppercasing. `Filtered` is a filtered sequence. `Maximum` is the greatest item of a sequence.

The `IPipe` and `ITap` rows carried the same framing, describing them as "a transformation as an object" and "a side effect as an object".

### What is the new behavior?

> Objects are results of behaviour. `Upper` is uppercase text, `Filtered` is a filtered sequence, `Maximum` is the greatest item of a sequence — each name says what the object is. Objects are composed by decoration, and the result is produced when it is asked for.

The two table rows read "a transformation" and "a side effect".

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

n/a

###  Other information

Follow-up to #45. The examples are checked against the code: `Upper`, `Filtered` and `Maximum` all exist under those names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JEnddMezkQP2S6sycx59B5)_