### PR TITLE
Document when code runs; fix Head reading past its limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,100 @@ dotnet add package Tonga
 
 Target: `net9.0`.
 
+## When code runs
+
+**Building objects runs nothing. Code runs when a materializing call is made.** Every type has one, named after what it hands back:
+
+| Type | Materializes with |
+|---|---|
+| `IText` | `Str()` |
+| `IScalar<T>` | `Value()` |
+| `IBytes` | `Raw()` |
+| `INumber` | `Int()`, `Long()`, `Double()`, `Float()` |
+| `IFact` | `IsTrue()`, `IsFalse()` |
+| `IConduit` | `Stream()` |
+| `IOptional<T>` | `Value()` |
+| `IPair<K,V>` | `Value()` |
+| `IEnumerable<T>` | `foreach`, `GetEnumerator()` |
+
+```csharp
+var text =
+    new Uri("https://example.org/data.txt")
+        .AsConduit()
+        .AsText();          // nothing requested, nothing read
+
+var content = text.Str();   // the request happens here
+```
+
+Composition therefore costs close to nothing: each step in a chain is one allocation holding a reference to the step before it. A chain of ten decorators that is never materialized does ten allocations and no work. Building a chain in a branch that turns out to be unused costs the allocations alone.
+
+**The `As` prefix marks composition.** A call named `As…` wraps and returns; it computes nothing:
+
+```csharp
+text.AsUpper()              // an uppercase text — nothing uppercased yet
+items.AsFiltered(…)         // a filtered sequence — nothing tested yet
+items.AsSorted()            // a sorted sequence — nothing compared yet
+conduit.AsText()            // a text over a stream — nothing read yet
+items.AsSticky()            // a buffered sequence — the buffer is still empty
+```
+
+The calls without the prefix hand back a different abstraction, and defer in the same way. `items.Length()` is an `IScalar<long>` that counts on `Value()`; `items.Contains(…)` is an `IFact` that searches on `IsTrue()`:
+
+```csharp
+var count = items.Length();   // nothing counted
+count.Value();                // counted here
+```
+
+**Enumerables** run per item where the operation allows it. `AsMapped` maps the current item while `MoveNext` advances, `AsFiltered` tests it there:
+
+```csharp
+var names =
+    people
+        .AsMapped(p => p.Name)          // p.Name not read yet
+        .AsFiltered(n => n.Length > 3);
+
+foreach (var name in names) { … }       // mapping and filtering run per item
+```
+
+`AsHead(3)` therefore reads three items, and `HasAtLeast(3)` stops after three.
+
+Operations that need every item before they can hand out the first one are the exception. `AsSorted`, `AsSortedBy` and `AsReversed` copy the source into a list and sort or reverse it — that work happens at the first step of the iteration, not spread across it:
+
+```csharp
+var sorted = items.AsSorted();   // nothing read, nothing compared
+
+var e = sorted.GetEnumerator();
+e.MoveNext();                    // the whole source is read and sorted here
+```
+
+They stay lazy in the sense that matters for composition: building the chain runs nothing. What changes is that the first `MoveNext` costs the whole sequence. The same holds for `Maximum`, `Minimum`, `AsReduced` and `Length`, which drain the source when their `Value()` is called.
+
+**Maps are lazy.** Constructing one runs nothing. The first access builds the key index; a value set up with a lambda runs when that key is asked for, and asking for one key leaves the others untouched:
+
+```csharp
+var config =
+    new AsMap<string, string>(
+        new AsPair<string, string>("host", () => "localhost"),
+        new AsPair<string, string>("secret", () => ReadSecretFromVault())
+    );
+
+var host = config["host"];     // ReadSecretFromVault has not been called
+```
+
+`Keys()` builds the index without materializing any value, and `Lazy(key)` hands back a `Func<Value>` that defers even the lookup.
+
+**To keep a result, close the chain with `AsSticky`.** It buffers what it wraps and serves later reads from the buffer:
+
+```csharp
+var names =
+    people
+        .AsMapped(p => p.Name)
+        .AsFiltered(n => n.Length > 3)
+        .AsSticky();           // computed once, on first enumeration
+```
+
+`AsSticky` is available for enumerables, lists, maps and scalars. Placing it at the end of a chain buffers once; without it, every pass recomputes. [Evaluation without default caching](#evaluation-without-default-caching) explains why this is the caller's decision.
+
 ## Principle
 
 Objects are results of behaviour. `Upper` is uppercase text, `Filtered` is a filtered sequence, `Maximum` is the greatest item of a sequence — each name says what the object is. Objects are composed by decoration, and the result is produced when it is asked for.

--- a/src/Tonga/Enumerable/Head.cs
+++ b/src/Tonga/Enumerable/Head.cs
@@ -40,7 +40,7 @@ namespace Tonga.Enumerable
             var max = limit();
             var taken = 0;
             var enumerator = source.GetEnumerator();
-            while (enumerator.MoveNext() && taken < max)
+            while (taken < max && enumerator.MoveNext())
             {
                 taken++;
                 yield return enumerator.Current;

--- a/tests/Tonga.Tests/Enumerable/HeadTest.cs
+++ b/tests/Tonga.Tests/Enumerable/HeadTest.cs
@@ -33,6 +33,22 @@ namespace Tonga.Tests.Enumerable
         }
 
         [Fact]
+        public void ReadsNoMoreItemsThanTheLimit()
+        {
+            var advanced = 0;
+            Assert.Equal(
+                3,
+                new SumOf(
+                    (0, 1, 2, 3, 4)
+                        .AsEnumerable()
+                        .OnEach(_ => advanced++)
+                        .AsHead(3)
+                ).Int()
+            );
+            Assert.Equal(3, advanced);
+        }
+
+        [Fact]
         public void LimitOfZeroProducesEmptyEnumerable()
         {
             Assert.Empty(


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [ ] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

The build box is unchecked: prepared without a .NET SDK available, so nothing here has been compiled or run. Branch is `main` (`7b145e1`) plus two commits.

### What kind of change does this PR introduce?** (check one with "x")
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: documentation

### What is the current behavior? (You can also link to an open issue here)

**Deferred evaluation was undocumented.** The README said results are produced when asked for, without saying which call does the asking, what composition costs, or how far a chain runs per item. The `As` prefix went unexplained.

**`Head` reads one item past its limit.** `Produced` advanced the source before checking the counter:

```csharp
while (enumerator.MoveNext() && taken < max)
```

`AsHead(3)` pulled a fourth item before stopping. The yielded items were right, which is why the existing tests pass either way, but an expensive, side-effecting or blocking source was read further than asked, and `AsHead(0)` touched the source at all.

### What is the new behavior?

`Head` checks the counter first, so it reads exactly as many items as the limit. Same fix shape as `HasAtLeast` in #44. A test now counts how far the source is advanced.

A new opening section, **When code runs**, placed ahead of Principle:

- a table of each type's materializing call — `Str()`, `Value()`, `Raw()`, `IsTrue()`, `Stream()`, `foreach`
- composition cost: one allocation per step and no work, so a chain built in an unused branch costs the allocations alone
- **the `As` prefix as the marker of composition**, with examples (`AsUpper`, `AsFiltered`, `AsSorted`, `AsText`, `AsSticky` — each wraps and returns), plus the unprefixed calls that hand back `IScalar` or `IFact` and defer the same way
- enumerables running per item, with `AsHead(3)` reading three and `HasAtLeast(3)` stopping after three
- **the exceptions**: `AsSorted`, `AsSortedBy` and `AsReversed` copy the source into a list and sort or reverse it at the first `MoveNext`, so composition stays free while the first step costs the whole sequence; `Maximum`, `Minimum`, `AsReduced` and `Length` drain on `Value()`
- **maps as lazy maps**: constructing runs nothing, the first access builds the key index, and a value set up with a lambda runs when that key is asked for — asking for one key leaves the others untouched; `Keys()` materializes no value and `Lazy(key)` defers the lookup too
- **`AsSticky`** to keep a result at the end of a chain, available for enumerables, lists, maps and scalars, pointing at the existing section on why that is the caller's decision

Every claim was checked against the code: `Sorted` and `SortedBy` build a `List<T>` and sort inside `GetEnumerator`, `Reversed` does the same in its `Produced`, `Distinct` stays per-item on a `HashSet`, `AsMap` holds a `Lazy<IDictionary<Key, IPair<Key, Value>>>` and calls `Value()` only on the pair being indexed, and `AsPair(key, Func<TValue>)` reports `IsLazy() == true`.

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

n/a. `Head` yields the same items as before; only how far it advances the source changes.

###  Other information

`HasMoreThan` and `HasLessThan` carry the same condition order as `Head` did and read one item more than they need to answer. Their results are correct, so I left them alone — say the word and I will bring them in line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JEnddMezkQP2S6sycx59B5)_