### PR TITLE
Open the README with the principle

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,36 @@ dotnet add package Tonga
 
 Target: `net9.0`.
 
+## Principle
+
+Objects are results of behaviour. `Upper` is uppercase text, `Filtered` is a filtered sequence, `Maximum` is the greatest item of a sequence — each name says what the object is. Objects are composed by decoration, and the result is produced when it is asked for.
+
+```csharp
+using Tonga.Enumerable;
+using Tonga.Text;
+
+("hello", "world", "damn")
+    .AsEnumerable()
+    .AsMapped(word => word.AsText().AsUpper())
+    .ItemAt(0)
+    .Value()
+    .Str();                                     // "HELLO"
+```
+
+Every link of the chain is a class and can be constructed directly:
+
+```csharp
+new ItemAt<IText>(
+    new Mapped<string, IText>(
+        word => new Upper(new AsText(word)),
+        new AsEnumerable<string>("hello", "world", "damn")
+    ),
+    0
+).Value().Str();
+```
+
+Both forms create the same objects. The extensions are named `…Smarts` (`EnumerableSmarts`, `TextSmarts`, `IOSmarts`, …) and arrive with the `using` of their namespace.
+
 ## When code runs
 
 **Building objects runs nothing. Code runs when a materializing call is made.** Every type has one, named after what it hands back:
@@ -106,36 +136,6 @@ var names =
 ```
 
 `AsSticky` is available for enumerables, lists, maps and scalars. Placing it at the end of a chain buffers once; without it, every pass recomputes. [Evaluation without default caching](#evaluation-without-default-caching) explains why this is the caller's decision.
-
-## Principle
-
-Objects are results of behaviour. `Upper` is uppercase text, `Filtered` is a filtered sequence, `Maximum` is the greatest item of a sequence — each name says what the object is. Objects are composed by decoration, and the result is produced when it is asked for.
-
-```csharp
-using Tonga.Enumerable;
-using Tonga.Text;
-
-("hello", "world", "damn")
-    .AsEnumerable()
-    .AsMapped(word => word.AsText().AsUpper())
-    .ItemAt(0)
-    .Value()
-    .Str();                                     // "HELLO"
-```
-
-Every link of the chain is a class and can be constructed directly:
-
-```csharp
-new ItemAt<IText>(
-    new Mapped<string, IText>(
-        word => new Upper(new AsText(word)),
-        new AsEnumerable<string>("hello", "world", "damn")
-    ),
-    0
-).Value().Str();
-```
-
-Both forms create the same objects. The extensions are named `…Smarts` (`EnumerableSmarts`, `TextSmarts`, `IOSmarts`, …) and arrive with the `using` of their namespace.
 
 ## Compared to LINQ
 


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

README only, no code touched. Branch is `main` (`c840b25`) plus one commit.

### What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: documentation

### What is the current behavior? (You can also link to an open issue here)

`When code runs` was the first section, ahead of `Principle`. A reader met the evaluation rules before learning what the objects are.

### What is the new behavior?

`Principle` opens the document, `When code runs` follows it. Its closing line — the result is produced when it is asked for — now leads into the section that says which call does the asking.

Section order:

1. Principle
2. When code runs
3. Compared to LINQ
4. Evaluation without default caching
5. Fluent API and EO principles
6. No fail objects
7. One stream interface
8. Core abstractions
9. Differences to Yaapii.Atoms

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

n/a

###  Other information

Reordering only. Sorting the lines of the file before and after the change gives the same checksum, so no wording was touched. Follow-up to #47.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JEnddMezkQP2S6sycx59B5)_