### PR TITLE
Add a Why Tonga section

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,32 @@ dotnet add package Tonga
 
 Target: `net9.0`.
 
+## Why Tonga
+
+EO in C# tends to fail at the call site. The object model is sound and the reading is not:
+
+```csharp
+new ItemAt<IText>(new Mapped<string, IText>(fn, new AsEnumerable<string>(…)), 0).Value().Str()
+```
+
+After a few weeks of that, a team writes methods again. Tonga keeps the objects and fixes the call site. The fluent surface is syntax and holds no behaviour: of 451 smarts, 449 are exactly `new X(…)`, and the two others compose wrappers that follow the same rule.
+
+What that buys:
+
+- **Objects named as results.** `Upper`, `Filtered`, `Maximum` — nouns for what comes out. A chain reads as a composition of things.
+- **Every step is a hook point.** Each link is an object with one method, so `AsSticky`, `LoggingOnReadConduit`, `RetryOnError`, `BackFalling` or `ExceptionSwap` wrap around any step without touching it.
+- **Your own types join in.** 14 envelope classes are the extension point. `MyConfig : MapEnvelope` is accepted wherever an `IMap` is, and gets the decorators with it. The library is meant to be extended with domain objects.
+- **Evaluation belongs to the caller.** Composition costs one allocation per step, work happens at materialization, buffering happens where `AsSticky` is placed.
+- **Small enough to read.** 208 public types, roughly 15,000 lines. For a library whose objects end up inside your own, that matters.
+
+### When it does not fit
+
+Measured as a utility library, LINQ and the BCL win on reach, tooling, framework coverage and runtime optimization. The gain here is not in the operations; it is in what the surrounding code looks like.
+
+The question that decides it: should the domain consist of objects that are decorated, or of data passed through functions? For the second, everything here is in the way.
+
+Also worth knowing before adopting: `net9.0` only, no concurrency guards ([What is missing](#what-is-missing)), and a 0.x version, so names still move between releases.
+
 ## Principle
 
 Objects are results of behaviour. `Upper` is uppercase text, `Filtered` is a filtered sequence, `Maximum` is the greatest item of a sequence — each name says what the object is. Objects are composed by decoration, and the result is produced when it is asked for.


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] I made sure that my code builds
- [x] I merged the master into this branch before pushing
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

README only, no code touched. Branch is `main` (`0a701bc`) plus one commit.

### What kind of change does this PR introduce?** (check one with "x")
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: documentation

### What is the current behavior? (You can also link to an open issue here)

The README said what Tonga is and how it behaves, and never said why to pick it. A reader arriving from Atoms, from Cactoos or from a LINQ codebase found the mechanics before any reason to care about them.

### What is the new behavior?

A `Why Tonga` section between the fork paragraph and `Principle`.

It opens on the problem the smarts solve — EO in C# tends to fail at the call site, and after a few weeks of nested constructors a team writes methods again — and states that the fluent surface holds no behaviour, with the count backing it: of 451 smarts, 449 are exactly `new X(…)`, and the two others compose wrappers under the same rule.

Then what follows from that:

- objects named as results, so a chain reads as a composition of things
- every step a hook point, since each link is an object with one method
- domain types joining in through the 14 envelope classes
- evaluation owned by the caller
- a size that can be read: 208 public types, roughly 15,000 lines

A `When it does not fit` subsection carries the other side: LINQ and the BCL win when the goal is a utility library, the deciding question is whether the domain is built from decorated objects or from data passed through functions, and the adoption facts are `net9.0` only, no concurrency guards, and 0.x naming.

### Does this PR introduce a breaking change? (check one with "x")
- [ ] Yes
- [x] No

### If this PR contains a breaking change, please describe the impact and migration path for existing applications

n/a

###  Other information

The figures were recounted against this commit rather than carried over: 208 public types, 15.075 lines under `src/Tonga`, 14 envelope classes, 451 extensions with 449 pure wrappers.

Follow-up to #48. The branch still held #48's pre-squash commit, whose content is in `main` already, so it was force-pushed over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01JEnddMezkQP2S6sycx59B5)_